### PR TITLE
Ignore trailing whitespaces in *.md

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -6,6 +6,7 @@ root = true
 [*]
 end_of_line = lf
 insert_final_newline = true
+trim_trailing_whitespace = true
 
 [*.{md,markdown}]
-trim_trailing_whitespace = true
+trim_trailing_whitespace = false


### PR DESCRIPTION
Because they are needed for linebreak