### PR TITLE
修复 testing/threearchtest.md markdown 引用

### DIFF
--- a/testing/threearchtest.md
+++ b/testing/threearchtest.md
@@ -227,7 +227,7 @@ Rust 对文档的哲学，是不要单独写文档，一是代码本身是文档
 
 比如，我们给上面库加点文档：
 
-```rust
+``````rust
 //! The `adder` crate provides functions that add numbers to other numbers.
 //!
 //! # Examples
@@ -259,7 +259,7 @@ mod tests {
       assert_eq!(4, add_two(2));
    }
 }
-```
+``````
 
 
 运行 `cargo test`，结果如下：


### PR DESCRIPTION
修复 markdown 引用. 

之前的代码, 在 github (https://github.com/rustcc/RustPrimer/blob/master/testing/threearchtest.md) 
上显示正常, 
但是在 这里 https://rust-china.org/rust-primer/latest/testing/threearchtest.html 显示不正常. 
