### PR TITLE
修复了安装中的链接

### DIFF
--- a/install/install_rust_on_linux.md
+++ b/install/install_rust_on_linux.md
@@ -43,7 +43,7 @@ Rust 提供简单的一键安装，命令如下：
 **注意**
 
 除了稳定版之外，Rust 还提供了 Beta 和 Nightly 版本，下载地址如下：
-https://www.rust-lang.org/downloads.html
+https://www.rust-lang.org/zh-CN/other-installers.html
 
 如果你不想安装 Rust 在你的电脑上，但是你还是像尝试一下 rust，那么这里有一个在线的环境：http://play.rust-lang.org/
 

--- a/install/install_rust_on_mac_os.md
+++ b/install/install_rust_on_mac_os.md
@@ -44,7 +44,7 @@ Rust 提供简单的一键安装，命令如下：
 **注意**
 
 除了稳定版之外，Rust 还提供了 Beta 和 Nightly 版本，下载地址如下：
-https://www.rust-lang.org/downloads.html
+https://www.rust-lang.org/zh-CN/other-installers.html
 
 如果你不想安装 Rust 在你的电脑上，但是你还是像尝试一下 rust，那么这里有一个在线的环境：http://play.rust-lang.org/
 

--- a/install/install_rust_on_windows.md
+++ b/install/install_rust_on_windows.md
@@ -6,7 +6,7 @@ Rust在Windows上的安装和你在windows上安装其它软件一样。
 
 ### 1、下载安装包：
 
-  [下载地址](https://www.rust-lang.org/downloads.html)
+  [下载地址](https://www.rust-lang.org/zh-CN/other-installers.html)
 
   Rust提供了多个版本和多个平台的安装包，下载对应的即可，此处我们以[1.6.0](https://static.rust-lang.org/dist/rust-1.6.0-x86_64-pc-windows-gnu.msi)的稳定版为例。
 

--- a/install/rustup.md
+++ b/install/rustup.md
@@ -1,6 +1,6 @@
 # Rust 版本管理工具: rustup
 
-rustup 是rust官方的版本管理工具。
+rustup 是rust官方的版本管理工具。应当作为安装 Rust 的首选。
 
 项目主页是: <https://github.com/rust-lang-nursery/rustup.rs>
 
@@ -25,7 +25,7 @@ rustup 是rust官方的版本管理工具。
 
 ### Windows
 
-在[rustup的主页](http://www.rustup.rs)下载并运行rustup-init.exe,并按照提示选择选项。
+在[rustup的主页](http://www.rustup.rs)下载并运行[rustup-init.exe](https://win.rustup.rs/),并按照提示选择选项。
 
 在Windows下工具链会安装到`%USERPROFILE%\.cargo\bin`文件夹下并添加到`$PATH`环境变量。
 


### PR DESCRIPTION
官方网站中的download页面已经不复存在
rustup目前作为官方推荐的安装方式